### PR TITLE
修改timezone.now() 为 timezone.now

### DIFF
--- a/chapter01.html
+++ b/chapter01.html
@@ -232,7 +232,7 @@ class Post(models.Model):
     slug = models.SlugField(max_length=250, unique_for_date='publish')
     author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='blog_posts')
     body = models.TextField()
-    publish = models.DateTimeField(default=timezone.now())
+    publish = models.DateTimeField(default=timezone.now)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
     status = models.CharField(max_length=10, choices=STATUS_CHOICES, default='draft')


### PR DESCRIPTION
The default value for the field. This can be a value or a callable object. If callable it will be called every time a new object is created.
来自django文档  https://docs.djangoproject.com/en/2.2/ref/models/fields/#django.db.models.Field.default    

如果你加了括号, 那 default 就一直是你开始 python manage.py runserver 的时间, 不加括号每次添加都会重新调用函数获取最新时间